### PR TITLE
Propose removal of General Meeting schedule from policies

### DIFF
--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -28,7 +28,7 @@ An applicant is to be considered having tendered resignation if the Application 
 
 #### ARTICLE 5. GENERAL MEETING SCHEDULE
 
-Whenever possible, General Meetings are to be held on the second Sunday of each calendar month, from 1:00 PM on, at the Space. Exceptions are generally made for long weekends.
+Whenever possible, General Meetings are to be held on a Sunday within the calendar quarter, from 1:00 PM on, at the Space. Exceptions are generally made for long weekends.
 
 #### ARTICLE 6. BOARD MEETING SCHEDULE
 

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -26,9 +26,9 @@ Members who have not paid their fees or dues within six calendar months may have
 
 An applicant is to be considered having tendered resignation if the Application Fee has not been paid within three months of application.
 
-#### ARTICLE 5. GENERAL MEETING SCHEDULE
+#### ARTICLE 5.
 
-Whenever possible, General Meetings are to be held on a Sunday within the calendar quarter, from 1:00 PM on, at the Space. Exceptions are generally made for long weekends.
+*Removed*.
 
 #### ARTICLE 6. BOARD MEETING SCHEDULE
 


### PR DESCRIPTION
Rationale: There are no bylaws which require this to be in the policies, and the bylaws have fixed scheduling (once per calendar quarter) and minimum notice periods. This policy is an artifact of previous bylaws and can be removed.