### PR TITLE
Propose adjustments to Directors Meeting schedule and notice

### DIFF
--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -145,7 +145,7 @@ Updated: September 24, 2024
         1. The Board shall meet at least monthly.
         2. The Board may set regulations governing the calling and medium of its meetings (notice, date, time, and place), the conduct of business thereat, and generally as to the conduct of its affairs.  These will be documented in The Society Policies.
         3. The President shall call and chair the meetings.  The President shall also call a meeting if any two Directors make such a request by providing notice or while having the floor at a general meeting or Board meeting, and state the business for the meeting.
-        4. Three days notice for regular Directors Meetings is provided to each Director.  As much notice as is possible shall be given for unscheduled or urgent meetings.
+        4. *Removed*.
         5. Directors Meetings may be held without notice if a quorum of The Board is present, provided that any business transactions at such a meeting shall be ratified at the next regularly called Directors Meeting; otherwise they shall be null and void.
         6. Three Directors shall be considered a quorum for all Directors Meetings; votes shall be passed by a simple majority unless otherwise agreed upon.
         7. If there is no quorum, the chairperson may adjourn the meeting to the same time, place, and day of the following week.  If urgent matters requiring quorum have been tabled as a result, The Directors present at this later meeting shall constitute quorum regardless of their number.

--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -142,10 +142,10 @@ Updated: September 24, 2024
 
     6. Directors Meetings
 
-        1. The Board shall meet as often as may be required in carrying out its duties and responsibilities or at least monthly.
+        1. Where the Board is not performing its duties and responsibilities monthly, the Board shall meet at least monthly.
         2. The Board may set regulations governing the calling and medium of its meetings (notice, date, time, and place), the conduct of business thereat, and generally as to the conduct of its affairs.  These will be documented in The Society Policies.
         3. The President shall call and chair the meetings.  The President shall also call a meeting if any two Directors make such a request by providing notice or while having the floor at a general meeting or Board meeting, and state the business for the meeting.
-        4. Seven days notice for regular Directors Meetings is provided to each Director.  As much notice as is possible shall be given for unscheduled or urgent meetings.
+        4. Three days notice for regular Directors Meetings is provided to each Director.  As much notice as is possible shall be given for unscheduled or urgent meetings.
         5. Directors Meetings may be held without notice if a quorum of The Board is present, provided that any business transactions at such a meeting shall be ratified at the next regularly called Directors Meeting; otherwise they shall be null and void.
         6. Three Directors shall be considered a quorum for all Directors Meetings; votes shall be passed by a simple majority unless otherwise agreed upon.
         7. If there is no quorum, the chairperson may adjourn the meeting to the same time, place, and day of the following week.  If urgent matters requiring quorum have been tabled as a result, The Directors present at this later meeting shall constitute quorum regardless of their number.

--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -142,7 +142,7 @@ Updated: September 24, 2024
 
     6. Directors Meetings
 
-        1. Where the Board is not performing its duties and responsibilities monthly, the Board shall meet at least monthly.
+        1. The Board shall meet at least monthly.
         2. The Board may set regulations governing the calling and medium of its meetings (notice, date, time, and place), the conduct of business thereat, and generally as to the conduct of its affairs.  These will be documented in The Society Policies.
         3. The President shall call and chair the meetings.  The President shall also call a meeting if any two Directors make such a request by providing notice or while having the floor at a general meeting or Board meeting, and state the business for the meeting.
         4. Three days notice for regular Directors Meetings is provided to each Director.  As much notice as is possible shall be given for unscheduled or urgent meetings.

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -32,7 +32,7 @@ Whenever possible, General Meetings are to be held on the second Sunday of each 
 
 #### ARTICLE 6. BOARD MEETING SCHEDULE
 
-The Board generally meets every second Thursday evening.
+Board Meetings are generally held on weekday evenings when scheduled. At least one Director is expected to attend scheduled public access times to the Space, such as during public tours and open houses.
 
 #### ARTICLE 7. COMPENSATION AND EXPENSES
 

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -32,7 +32,7 @@ Whenever possible, General Meetings are to be held on the second Sunday of each 
 
 #### ARTICLE 6. BOARD MEETING SCHEDULE
 
-Board Meetings are generally held on weekday evenings when scheduled. At least one Director is expected to attend scheduled public access times to the Space, such as during public tours and open houses.
+The Board meets the first Tuesday evening of the month at the Space. Additional meetings may be called as needed with as much as notice as possible.
 
 #### ARTICLE 7. COMPENSATION AND EXPENSES
 


### PR DESCRIPTION
Rationale: There are already bylaws which allow the Board to meet with effectively zero notice, especially in emergency situations. This removes a minimum notice period for a regularly scheduled meeting (notice is infinite with the proposed Policy change), but still requires that off-cycle meetings ratify their business at the next on-cycle meeting. The Bylaw regarding frequency is simplified to represent the proposed policy change.