### PR TITLE
Propose alterations to the Directors Meeting logistics

### DIFF
--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -150,7 +150,7 @@ Updated: September 24, 2024
         6. Three Directors shall be considered a quorum for all Directors Meetings; votes shall be passed by a simple majority unless otherwise agreed upon.
         7. If there is no quorum, the chairperson may adjourn the meeting to the same time, place, and day of the following week.  If urgent matters requiring quorum have been tabled as a result, The Directors present at this later meeting shall constitute quorum regardless of their number.
         8. Each Director has one vote.
-        9. Directors Meetings are open to Members of the Society, but only Directors may vote.  A majority vote of The Board may ask any other Member or other persons to leave.
+        9. Directors Meetings are open to Members in Good Standing, but only Directors may vote.  A majority vote of The Board may ask any other Member or other persons to leave.
         10. A majority vote of The Board may move a meeting, or any portion thereof, in-camera at any time.
         11. All Directors may agree to and sign a resolution at any time.  This resolution is as valid as one passed at any Directors Meeting.  It is not necessary to give notice or to call a Directors Meeting for the resolution in this case.  The date on the resolution is the date it is passed.
         12. Any member of The Board unable to attend a meeting may send a proxy to represent them at that meeting.  The proxy shall:

--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -157,7 +157,7 @@ Updated: September 24, 2024
 
             1. Represent The Director, including voting on their behalf;
             2. Be a Member in Good Standing;
-            3. Not be another Director.
+            3. Not be another Director already acting as a proxy;
 
         13. The ultimate authority for conducting any meeting of The Society and all its committees shall be an unabridged edition of Robert’s _Rules of Order_.
     7. Duties of the President

--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -153,11 +153,11 @@ Updated: September 24, 2024
         9. Directors Meetings are open to Members in Good Standing, but only Directors may vote.  A majority vote of The Board may ask any other Member or other persons to leave.
         10. A majority vote of The Board may move a meeting, or any portion thereof, in-camera at any time.
         11. All Directors may agree to and sign a resolution at any time.  This resolution is as valid as one passed at any Directors Meeting.  It is not necessary to give notice or to call a Directors Meeting for the resolution in this case.  The date on the resolution is the date it is passed.
-        12. Any member of The Board unable to attend a meeting may send a proxy to represent them at that meeting.  The proxy shall:
+        12. Directors shall not be able to assign proxies to represent them at Directors Meetings.
 
-            1. Represent The Director, including voting on their behalf;
-            2. Be a Member in Good Standing;
-            3. Not be another Director already acting as a proxy;
+            1. *Removed*.
+            2. *Removed*.
+            3. *Removed*.
 
         13. The ultimate authority for conducting any meeting of The Society and all its committees shall be an unabridged edition of Robert’s _Rules of Order_.
     7. Duties of the President


### PR DESCRIPTION
Rationale: All other aspects of the Society's operations are only available to Members in Good Standing, so it feels weird to allow Directors Meetings to be open to Members not in Good Standing too - this is modernized to capture expected intent. Like committee meetings, non-member guests are welcome at Board meetings if invited. Proxies are denied as it's unlikely that a non-Director will have sufficient context for a meeting. Further, there doesn't appear to be any motivating reason to support proxies for directors meetings: attendance is ideal. 