### PR TITLE
Propose clarifications and bug fixes to memberships

### DIFF
--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -46,7 +46,7 @@ Updated: September 24, 2024
     2. Fees and Dues
 
         1. Application Fees and Membership Dues, if any, for The Society shall be documented accordingly in The Society Policies.
-        2. Membership Dues, if any, shall be due monthly from each member. Membership Dues may be paid in advance at the discretion or request of The Society or the individual Member in question.
+        2. Membership Dues, if any, shall be due monthly from each member. Membership Dues may be paid at most 3 months in advance at the discretion or request of The Society or the individual Member in question.
         3. Members in good standing will be notified a minimum of one calendar month in advance of changes to the monthly membership dues.
         4. All fees and dues shall be considered non-refundable.
 
@@ -77,7 +77,7 @@ Updated: September 24, 2024
 
     5. Termination or Suspension of Membership
 
-        1. Any Member may resign from The Society by providing written notice to a Director.
+        1. Any Member may resign from The Society by providing written notice to The Board.
         2. The membership of a Member is ended upon death.
         3. If a Member is in arrears for a period of time as defined in The Society policies, their membership may be terminated by The Board.
         4. The Society may, upon a majority vote of all members, or a three-quarters majority vote at a regular meeting with quorum, expel any Member for any cause which is deemed sufficient in the interests of the Society.

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -12,15 +12,15 @@ The current Application Fees for ENTS membership are currently not set.
 
 #### ARTICLE 3. MEMBERSHIP DUES AND CLASSIFICATIONS
 
-The current monthly Membership Dues are $100 CAD. Members have the option to pay for a yearly membership for $1000 CAD for twelve consecutive months of membership from the date of purchase. The Board may, in its sole discretion, extend lowered rates for Membership Dues to individuals as the Board deems suitable. All members paying rates under this classification, lowered or otherwise, are Members in Good Standing.
+All memberships begin on the date of purchase or as arranged in Bylaw 4.2.2. The monthly Membership Dues are $100 CAD. Members have the option to pre-pay $1000 CAD for tweleve consecutive months of membership. The Board may, in its sole discretion, extend lowered rates for Membership Dues to individuals as the Board deems suitable. All members paying rates under this classification, lowered or otherwise, are Members in Good Standing.
 
 The Board may offer sponsored memberships to individuals or organizations at its sole discretion. Members holding a sponsored membership have the same rights as Members in Good Standing with the exception of the right to vote.
 
-Any non-member who donates funds to the Society on a regular basis holds a Friends of ENTS Membership. Friends of ENTS do not receive any rights beyond those available to non-members.
+Recurring or single financial donations to the Society shall not be considered memberships.
 
 The Board may, from time to time, create or offer promotional memberships to new or existing members of the Society. Promotional memberships are considered Members in Good Standing unless otherwise defined in the conditions of the membership or in the Society Policies.
 
-Members who have not paid their fees or dues within six calendar months may have their membership terminated by the Board.
+Members who have not paid their fees or dues within six calendar months of when they were due may have their membership terminated by the Board.
 
 #### ARTICLE 4. DEEMED WITHDRAWAL
 

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -12,7 +12,7 @@ The current Application Fees for ENTS membership are currently not set.
 
 #### ARTICLE 3. MEMBERSHIP DUES AND CLASSIFICATIONS
 
-All memberships begin on the date of purchase or as arranged in Bylaw 4.2.2. The monthly Membership Dues are $100 CAD. Members have the option to pre-pay $1000 CAD for tweleve consecutive months of membership. The Board may, in its sole discretion, extend lowered rates for Membership Dues to individuals as the Board deems suitable. All members paying rates under this classification, lowered or otherwise, are Members in Good Standing.
+The monthly Membership Dues are $100 CAD. Members have the option to pre-pay $1000 CAD for twelve consecutive months of membership. The Board may, in its sole discretion, extend lowered rates for Membership Dues to individuals as the Board deems suitable. All members paying rates under this classification, lowered or otherwise, are Members in Good Standing.
 
 The Board may offer sponsored memberships to individuals or organizations at its sole discretion. Members holding a sponsored membership have the same rights as Members in Good Standing with the exception of the right to vote.
 


### PR DESCRIPTION
Rationale:

* Not having bounds on advanced payment is high financial risk.
* Resignations should be sent to the Board generally to ensure maximum notice and context. This is in line with other notices members can give regarding their membership.
* A special carve-out for Friends of ENTS does not feel necessary. The single member on this rate will retain that rate, classified as a donation.
* Added clarity around when the Board may terminate memberships is always good.