### PR TITLE
Propose limits on membership dues being suspended/paused

### DIFF
--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -81,7 +81,7 @@ Updated: September 24, 2024
         2. The membership of a Member is ended upon death.
         3. If a Member is in arrears for a period of time as defined in The Society policies, their membership may be terminated by The Board.
         4. The Society may, upon a majority vote of all members, or a three-quarters majority vote at a regular meeting with quorum, expel any Member for any cause which is deemed sufficient in the interests of the Society.
-        5. Any member may temporarily suspend their membership by providing notice to The Board of their intent.
+        5. Any member may temporarily suspend their membership within the bounds of the Society Policies by providing notice to The Board of their intent.
 
     6. Membership Classifications
 

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -22,6 +22,8 @@ The Board may, from time to time, create or offer promotional memberships to new
 
 Members who have not paid their fees or dues within six calendar months may have their membership terminated by the Board.
 
+Members may temporarily suspend their membership while deferring their Membership Dues for 2 to 12 weeks. Members may temporarily suspend their membership up to two times in a calendar year when also deferring their Membership Dues. There are no limits to the duration or frequency of suspensions which do not defer Membership Dues. Members with a suspended membership, for any reason, are not Members in Good Standing for the duration of that suspension.
+
 #### ARTICLE 4. DEEMED WITHDRAWAL
 
 An applicant is to be considered having tendered resignation if the Application Fee has not been paid within three months of application.

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -22,7 +22,7 @@ The Board may, from time to time, create or offer promotional memberships to new
 
 Members who have not paid their fees or dues within six calendar months may have their membership terminated by the Board.
 
-Members may temporarily suspend their membership while deferring their Membership Dues for 2 to 12 weeks. Members may temporarily suspend their membership up to two times in a calendar year when also deferring their Membership Dues. There are no limits to the duration or frequency of suspensions which do not defer Membership Dues. Members with a suspended membership, for any reason, are not Members in Good Standing for the duration of that suspension.
+Members may temporarily suspend their membership while deferring their Membership Dues for 2 to 12 weeks. Members may temporarily suspend their membership up to two times in a calendar year when also deferring their Membership Dues. Members with a suspended membership, for any reason, are not Members in Good Standing for the duration of that suspension.
 
 #### ARTICLE 4. DEEMED WITHDRAWAL
 


### PR DESCRIPTION
Rationale: Members with suspended memberships *and* deferring the dues associated with that membership add financial risk to the Society. Instead, no limits are placed on suspensions without deferred dues (as is the case today), but some risk mitigation is in place regarding already-paid dues. Classifying suspended members as not in Good Standing limits a suspended member's ability to vote (among other rights) - this is intentional to minimize situations where "non-paying" members can still affect the Society's direction.

For interpretation clarity: members *may* suspend their membership for longer than 12 weeks or more than twice a year, however their payment will be fully captured by the Society. For example, if a member pays $100 for a monthly membership and starts their pause 2 weeks in for 20 weeks, at the 12 week mark their membership will automatically resume for 2 weeks to "spend" their outstanding dues before going back to suspended for another 6 weeks.