### PR TITLE
Propose that the Society operate on the last budget until a new one is approved

### DIFF
--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -275,7 +275,8 @@ Updated: September 24, 2024
 
     2. Budget and Expenditures
 
-        1. The President and Treasurer shall draw up a proposed budget for the coming fiscal year and present it to The Board for consideration prior to the Annual General Meeting.
+        1. The President and Treasurer shall draw up a proposed budget for the coming fiscal year and present it to The Board for consideration prior to the fiscal year starting.
+           1. The Society shall operate on the most recently approved budget if The Board has not approved a budget for the fiscal year, until a budget is approved.
         2. Expenditures of funds allocated in the budget shall have the approval of the Board before payment is made.
 
     3. Finance and Auditing


### PR DESCRIPTION
Rationale: Having a budget approved 1.5 months into the fiscal year isn't great, so move the timeline up for that. It also feels useful to have a clause that allows continued operation of the Society if for some reason a budget isn't approved in time - now that the Society has approved a budget, the clause will *always* have a budget to point at.