### PR TITLE
Propose a fix to when expenses need to be submitted by

### DIFF
--- a/bylaws/bylaws.md
+++ b/bylaws/bylaws.md
@@ -180,7 +180,7 @@ Updated: September 24, 2024
         2. Provides a detailed account of revenues and expenditures to The Board upon request; and
         3. Ensures an audited statement of the financial position of The Society is prepared and presented to the Annual General Meeting; and
         4. Submits monthly financial reports to The Board; and
-        5. Reports and reconciles the year’s expenditures within three weeks of the end of the fiscal year; and
+        5. Reports and reconciles the year’s expenditures within 1 week of the submission deadline for expenses in the Society Policies; and
         6. Oversees organization of fundraising committees; and
         7. Assists the President in the solicitation of financial assistance for The Society.
 

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -40,7 +40,7 @@ Members may receive payment as compensation for time spent working on projects o
 
 With prior Board approval, reasonable expenses incurred while carrying out duties of the Society may be reimbursed.
 
-All expenses must be submitted by the Annual General Meeting.
+All expenses for the previous fiscal year must be submitted at most two weeks before the Annual General Meeting following that fiscal year.
 
 No person may receive waived fees as compensation.
 

--- a/policies/01-general.md
+++ b/policies/01-general.md
@@ -40,7 +40,7 @@ Members may receive payment as compensation for time spent working on projects o
 
 With prior Board approval, reasonable expenses incurred while carrying out duties of the Society may be reimbursed.
 
-All expenses for the previous fiscal year must be submitted at most two weeks before the Annual General Meeting following that fiscal year.
+All expenses must be submitted within 30 days of the fiscal year closing.
 
 No person may receive waived fees as compensation.
 


### PR DESCRIPTION
Rationale: the financial reports need to be presented at the AGM, but if expenses can be accepted until the AGM then the reports can be wrong. Just make it "within 30 days of close" to allow time for the reports to be made.